### PR TITLE
Remove `assetsLocation` from default config when zipping

### DIFF
--- a/.ci/buildConnectorZip.sh
+++ b/.ci/buildConnectorZip.sh
@@ -21,6 +21,7 @@ wget https://github.com/nmshd/connector/releases/download/${CONNECTOR_VERSION}/c
 unzip connector-${CONNECTOR_VERSION}.zip
 
 npm install --save-exact @nmshd/connector-school-module@${SCHOOL_MODULE_VERSION} --omit=dev
+cat ../bundled.config.json | jq -r 'del(.modules.school.assetsLocation)' >./bundled.config.json
 
 zip -r "../connector-${SCHOOL_MODULE_VERSION}.zip" dist package.json package-lock.json bundled.config.json
 

--- a/.ci/buildConnectorZip.sh
+++ b/.ci/buildConnectorZip.sh
@@ -21,7 +21,6 @@ wget https://github.com/nmshd/connector/releases/download/${CONNECTOR_VERSION}/c
 unzip connector-${CONNECTOR_VERSION}.zip
 
 npm install --save-exact @nmshd/connector-school-module@${SCHOOL_MODULE_VERSION} --omit=dev
-cp ../bundled.config.json ./bundled.config.json
 
 zip -r "../connector-${SCHOOL_MODULE_VERSION}.zip" dist package.json package-lock.json bundled.config.json
 


### PR DESCRIPTION
# Readiness checklist

- [x] I ensured that the PR title is good enough for the changelog.
- [x] I labeled the PR.
- [x] I self-reviewed the PR.

# Description

`assetsLocation` should never be `/assets` on windows hosts which the zip is made for.
