### PR TITLE
Remove is technical

### DIFF
--- a/src/StudentsController.ts
+++ b/src/StudentsController.ts
@@ -42,7 +42,8 @@ export class StudentsController {
         pin?: string;
         additionalConsents: { title: string; mustBeAccepted?: boolean; consent: string; link: string }[];
     }): Promise<Student> {
-        const self = await this.services.transportServices.account.getIdentityInfo();
+        const identityInfo = await this.services.transportServices.account.getIdentityInfo();
+
         const request: RequestJSON = {
             "@type": "Request",
             items: [
@@ -67,7 +68,7 @@ export class StudentsController {
                                     "@type": "Consent",
                                     consent: "Dieser Kontakt kann keine Nachrichten von dir erhalten."
                                 },
-                                owner: self.value.address
+                                owner: identityInfo.value.address
                             },
                             mustBeAccepted: true
                         } satisfies CreateAttributeRequestItemJSON

--- a/src/StudentsController.ts
+++ b/src/StudentsController.ts
@@ -67,8 +67,7 @@ export class StudentsController {
                                     "@type": "Consent",
                                     consent: "Dieser Kontakt kann keine Nachrichten von dir erhalten."
                                 },
-                                owner: self.value.address,
-                                isTechnical: true
+                                owner: self.value.address
                             },
                             mustBeAccepted: true
                         } satisfies CreateAttributeRequestItemJSON


### PR DESCRIPTION
# Readiness checklist

- [x] I ensured that the PR title is good enough for the changelog.
- [x] I labeled the PR.
- [x] I self-reviewed the PR.

# Description

With the current implementation of the app isTechnical hides the attribute after it was accepted. As this attribute is NOT technical this is annoying and users will not understand that.
