### PR TITLE
Deleting an inactive student is not possible if autoMailBeforeOffboarding is turned on

### DIFF
--- a/src/StudentsController.ts
+++ b/src/StudentsController.ts
@@ -212,7 +212,6 @@ export class StudentsController {
             const relationship = await this.getRelationship(student.correspondingRelationshipId);
 
             if (this.autoMailBeforeOffboarding && relationship.status === RelationshipStatus.Active) {
-            
                 await this.sendMailBasedOnTemplateName(student, "offboarding");
             }
 

--- a/src/StudentsController.ts
+++ b/src/StudentsController.ts
@@ -211,7 +211,8 @@ export class StudentsController {
         if (student.correspondingRelationshipId) {
             const relationship = await this.getRelationship(student.correspondingRelationshipId);
 
-            if (this.autoMailBeforeOffboarding) {
+            if (this.autoMailBeforeOffboarding && relationship.status === RelationshipStatus.Active) {
+            
                 await this.sendMailBasedOnTemplateName(student, "offboarding");
             }
 


### PR DESCRIPTION
# Readiness checklist

- [x] I ensured that the PR title is good enough for the changelog.
- [x] I labeled the PR.
- [x] I self-reviewed the PR.

# Description

When the app is terminated from the app side it's not possible anymore to delete the student when the option autoMailBeforeOffboarding is turned on.
