### PR TITLE
UTF-8 Characters break PDF Templating without a proper error message

### DIFF
--- a/src/StudentsController.ts
+++ b/src/StudentsController.ts
@@ -205,7 +205,7 @@ export class StudentsController {
             if (error instanceof Error && error.message.includes("WinAnsi cannot encode")) {
                 throw new ApplicationError(
                     "error.schoolModule.onboardingPDFNotUTF8Compatible",
-                    `Trying to write a UTF-8 string to a PDF that is not UTF-8 compatible. Please check the template '${templateName}' for UTF-8 support.`
+                    `Cannot write a UTF-8 string to a PDF that is not UTF-8 compatible. Please check the template '${templateName}' for UTF-8 support.`
                 );
             }
 

--- a/src/StudentsController.ts
+++ b/src/StudentsController.ts
@@ -205,7 +205,7 @@ export class StudentsController {
             if (error instanceof Error && error.message.includes("WinAnsi cannot encode")) {
                 throw new ApplicationError(
                     "error.schoolModule.onboardingPDFNotUTF8Compatible",
-                    `Trying to write a UTF-8 string to a PDF that is not UTF-8 compatible. Please check the template ${templateName} for UTF-8 support.`
+                    `Trying to write a UTF-8 string to a PDF that is not UTF-8 compatible. Please check the template '${templateName}' for UTF-8 support.`
                 );
             }
 

--- a/src/StudentsController.ts
+++ b/src/StudentsController.ts
@@ -202,6 +202,13 @@ export class StudentsController {
         try {
             form.flatten();
         } catch (error) {
+            if (error instanceof Error && error.message.includes("WinAnsi cannot encode")) {
+                throw new ApplicationError(
+                    "error.schoolModule.onboardingPDFNotUTF8Compatible",
+                    `Trying to write a UTF-8 string to a PDF that is not UTF-8 compatible. Please check the template ${templateName} for UTF-8 support.`
+                );
+            }
+
             throw error;
         }
 

--- a/src/StudentsController.ts
+++ b/src/StudentsController.ts
@@ -199,7 +199,12 @@ export class StudentsController {
             form.getTextField("Apple").setImage(qrCode);
         }
 
-        form.flatten();
+        try {
+            form.flatten();
+        } catch (error) {
+            throw error;
+        }
+
         const pdfBytes = await pdfDoc.save();
         return Buffer.from(pdfBytes);
     }


### PR DESCRIPTION
# Readiness checklist

- [x] I ensured that the PR title is good enough for the changelog.
- [x] I labeled the PR.
- [x] I self-reviewed the PR.

# Description

Going from
```jsonc
{
    "error": {
        "code": "error.connector.unexpected",
        "details": "WinAnsi cannot encode \"\" (0x1f61c)",
        // ...
    }
}
```
to 
```jsonc
{
    "error": {
        "code": "error.schoolModule.onboardingPDFNotUTF8Compatible",
        "message": "Cannot write a UTF-8 string to a PDF that is not UTF-8 compatible. Please check the template template_onboarding.pdf for UTF-8 support.",
        // ...
    }
}
```

