### PR TITLE
The verbose query parameter is not handled properly

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -119,6 +119,13 @@ tasks:
   audit-log:
     desc: Get the audit log for a student
     cmds:
-      - "http -b GET localhost:8099/students/{{.STUDENT_ID}}/log 'X-API-KEY: This_is_a_test_APIKEY_with_30_chars+' 'Accept: application/json'"
+      - "http -b GET localhost:8099/students/{{.STUDENT_ID}}/log 'X-API-KEY: This_is_a_test_APIKEY_with_30_chars+' 'Accept: test/plain'"
+    requires:
+      vars: [STUDENT_ID]
+
+  audit-log-json:
+    desc: Get the audit log for a student
+    cmds:
+      - "http -b GET localhost:8099/students/{{.STUDENT_ID}}/log?verbose=true 'X-API-KEY: This_is_a_test_APIKEY_with_30_chars+' 'Accept: application/json' | jq"
     requires:
       vars: [STUDENT_ID]

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -115,3 +115,10 @@ tasks:
         sh: 'cat assets/Zeugnis.pdf | {{if eq OS "darwin"}}base64{{else}}base64 -w 0{{end}}'
     requires:
       vars: [STUDENT_ID]
+
+  audit-log:
+    desc: Get the audit log for a student
+    cmds:
+      - "http -b GET localhost:8099/students/{{.STUDENT_ID}}/log 'X-API-KEY: This_is_a_test_APIKEY_with_30_chars+' 'Accept: application/json'"
+    requires:
+      vars: [STUDENT_ID]

--- a/src/controllers/StudentsRESTController.ts
+++ b/src/controllers/StudentsRESTController.ts
@@ -56,7 +56,7 @@ export class StudentsRESTController extends BaseController {
         const student = await this.studentsController.getStudent(id);
         if (!student) throw RuntimeErrors.general.recordNotFound(Student);
 
-        const auditLog = await this.studentsController.getStudentAuditLog(student, !!verbose);
+        const auditLog = await this.studentsController.getStudentAuditLog(student, verbose === "true");
 
         switch (accept) {
             case "text/plain":

--- a/src/controllers/StudentsRESTController.ts
+++ b/src/controllers/StudentsRESTController.ts
@@ -51,12 +51,12 @@ export class StudentsRESTController extends BaseController {
         @PathParam("id") id: string,
         @ContextAccept accept: string,
         @ContextResponse response: express.Response,
-        @QueryParam("verbose") verbose: string
+        @QueryParam("verbose") verbose?: boolean
     ): Promise<Envelope | void> {
         const student = await this.studentsController.getStudent(id);
         if (!student) throw RuntimeErrors.general.recordNotFound(Student);
 
-        const auditLog = await this.studentsController.getStudentAuditLog(student, verbose === "true");
+        const auditLog = await this.studentsController.getStudentAuditLog(student, verbose);
 
         switch (accept) {
             case "text/plain":


### PR DESCRIPTION
# Readiness checklist

- [x] I ensured that the PR title is good enough for the changelog.
- [x] I labeled the PR.
- [x] I self-reviewed the PR.

# Description

Query params are strings so `"foo"` would be true too.